### PR TITLE
Adding sidebar component

### DIFF
--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 
 import EventLink from "./EventLink";
 import PostList from "./PostList";
+import SideNav from "./SideNav";
 
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
@@ -14,10 +15,6 @@ export default function Home(props) {
 
   const goToForum = (id) => {
     props.history.push(`/forum/${id}`);
-  };
-
-  const goToEvent = (event_id) => {
-    window.location.reload();
   };
 
   useEffect(() => {
@@ -38,20 +35,10 @@ export default function Home(props) {
 
   return (
     <div className={classes.root}>
-      <div className={classes.sidenav}>
-        <h1 className={classes.h2}>Event Threads</h1>
-        <List component="nav">
-          {events.map((event) => (
-            <>
-              <ListItem button onClick={() => goToEvent()}>
-                <EventLink eventtitle={event.title} />
-              </ListItem>
-            </>
-          ))}
-        </List>
+      <div className={classes.nav_post_container}>
+        <SideNav></SideNav>
+        <PostList goToForum={goToForum} {...props} />
       </div>
-
-      <PostList goToForum={goToForum} {...props} />
     </div>
   );
 }

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -1,44 +1,15 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
+import React from "react";
 
-import EventLink from "./EventLink";
-import PostList from "./PostList";
-import SideNav from "./SideNav";
+import SideNavHotPost from "./SideNavHotPost";
 
-import List from "@material-ui/core/List";
-import ListItem from "@material-ui/core/ListItem";
 import useStyles from "./styles/HomeStyles";
 
 export default function Home(props) {
   const classes = useStyles();
-  const [events, setEvents] = useState([]);
 
   const goToForum = (id) => {
     props.history.push(`/forum/${id}`);
   };
 
-  useEffect(() => {
-    // Fetching "events", would consist of sports: golf/soccer etc, and political events: 2020 US presidential election etc.
-    // Following Betfair's logic
-    const fetchEvents = async () => {
-      const result_events = await axios(
-        "https://jsonplaceholder.typicode.com/albums"
-      );
-      result_events.data = result_events.data.slice(0, 20);
-      setEvents(result_events.data);
-    };
-
-    // remove these console.logs once we've verified that this gets called at all the right times. (wait till we have a client side routing directing here)
-    console.log("FETCHING EVENTS DATA");
-    fetchEvents();
-  }, []);
-
-  return (
-    <div className={classes.root}>
-      <div className={classes.nav_post_container}>
-        <SideNav></SideNav>
-        <PostList goToForum={goToForum} {...props} />
-      </div>
-    </div>
-  );
+  return <SideNavHotPost categoryid="Home" {...props}></SideNavHotPost>;
 }

--- a/src/SideNav.jsx
+++ b/src/SideNav.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from "react";
+import useStyles from "./styles/SideNavStyles.js";
+import axios from "axios";
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import EventLink from "./EventLink";
+
+export default function SideNav(category_id, ReRenderCat) {
+  const [categories, setCategories] = useState([]);
+  const classes = useStyles();
+
+  //ReRenderCat is a function passed down by the parent as a prop which will reload the hotposts/eventdata with the new id
+  const goToEvent = (cat_title) => {
+    console.log(cat_title);
+    //ReRenderCat(new_cat_id);
+  };
+
+  useEffect(() => {
+    const fetchCategories = async (category_id) => {
+      const result_categories = await axios(
+        "https://jsonplaceholder.typicode.com/albums"
+      );
+      result_categories.data = result_categories.data.slice(0, 20);
+      setCategories(result_categories.data);
+    };
+
+    fetchCategories();
+  }, []);
+
+  return (
+    <div className={classes.root}>
+      <h3 className={classes.EventHeader}>Event Threads</h3>
+      <List component="nav">
+        {categories.map((category) => (
+          <>
+            <ListItem
+              className={classes.ListItem}
+              button
+              onClick={() => goToEvent(category.title)}
+            >
+              <EventLink eventtitle={category.title} />
+            </ListItem>
+          </>
+        ))}
+      </List>
+    </div>
+  );
+}

--- a/src/SideNav.jsx
+++ b/src/SideNav.jsx
@@ -1,12 +1,14 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
+
 import useStyles from "./styles/SideNavStyles.js";
+
 import axios from "axios";
 import List from "@material-ui/core/List";
 import ListItem from "@material-ui/core/ListItem";
+
 import EventLink from "./EventLink";
 
-export default function SideNav(category_id, ReRenderCat) {
-  const [categories, setCategories] = useState([]);
+export default function SideNav({ events }) {
   const classes = useStyles();
 
   //ReRenderCat is a function passed down by the parent as a prop which will reload the hotposts/eventdata with the new id
@@ -15,30 +17,18 @@ export default function SideNav(category_id, ReRenderCat) {
     //ReRenderCat(new_cat_id);
   };
 
-  useEffect(() => {
-    const fetchCategories = async (category_id) => {
-      const result_categories = await axios(
-        "https://jsonplaceholder.typicode.com/albums"
-      );
-      result_categories.data = result_categories.data.slice(0, 20);
-      setCategories(result_categories.data);
-    };
-
-    fetchCategories();
-  }, []);
-
   return (
     <div className={classes.root}>
       <h3 className={classes.EventHeader}>Event Threads</h3>
       <List component="nav">
-        {categories.map((category) => (
+        {events.map((event) => (
           <>
             <ListItem
               className={classes.ListItem}
               button
-              onClick={() => goToEvent(category.title)}
+              onClick={() => goToEvent(event)}
             >
-              <EventLink eventtitle={category.title} />
+              <EventLink eventtitle={event} />
             </ListItem>
           </>
         ))}

--- a/src/SideNavHotPost.jsx
+++ b/src/SideNavHotPost.jsx
@@ -1,0 +1,54 @@
+import React from "react";
+
+import SideNav from "./SideNav";
+import PostList from "./PostList";
+
+import useStyles from "./styles/SideNavHotPostStyles.js";
+import axios from "axios";
+
+export default function SideNavHotPost(props) {
+  const classes = useStyles();
+
+  const goToForum = (id) => {
+    props.history.push(`/forum/${id}`);
+  };
+
+  const fetchEventData = () => {
+    switch (props.categoryid) {
+      case "Home":
+        console.log("Grabbing baseline events for home page");
+        //const event_data = await axios.post(
+        //  "https://api.smarkets.com/v3/events/?state=new&state=upcoming&state=live&sort=id&limit=20",
+        //  {
+        //    headers: { crossdomain: true },
+        //  }
+        //);
+        const event_data = {
+          data: [
+            "Golf",
+            "Soccer",
+            "Tennis",
+            "Rugby",
+            "Darts",
+            "Swimming",
+            "Politics",
+          ],
+        };
+        return event_data.data;
+        break;
+
+      default:
+        console.log("UNKNOWN CATEGORY TYPE");
+        break;
+    }
+  };
+
+  const childEvents = fetchEventData();
+
+  return (
+    <div className={classes.root}>
+      <SideNav events={childEvents}> </SideNav>
+      <PostList goToForum={goToForum} {...props} />
+    </div>
+  );
+}

--- a/src/styles/EventLinkStyles.js
+++ b/src/styles/EventLinkStyles.js
@@ -3,11 +3,12 @@ import { makeStyles } from "@material-ui/core/styles";
 const useStyles = makeStyles({
   root: {
     width: "100%",
-  }, 
+  },
 
   link: {
-    border:"1px solid black"
-  }
+    textAlign: "center",
+    color: "white",
+  },
 });
 
 export default useStyles;

--- a/src/styles/HomeStyles.js
+++ b/src/styles/HomeStyles.js
@@ -1,27 +1,5 @@
 import { makeStyles } from "@material-ui/core/styles";
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    width: "100%",
-    backgroundColor: theme.palette.background.paper,
-    display: "flex",
-    flexDirection: "row",
-    alignItems: "flex-start",
-  },
-
-  HotPostHeader: {
-    fontSize: 40,
-    color: "red",
-  },
-
-  sidenav: {
-    backgroundColor: "lightgray",
-    border: "1px solid black",
-    marginTop: 30,
-    marginRight: 20,
-  },
-
-  HotPosts: {},
-}));
+const useStyles = makeStyles((theme) => ({}));
 
 export default useStyles;

--- a/src/styles/SideNavHotPostStyles.js
+++ b/src/styles/SideNavHotPostStyles.js
@@ -1,0 +1,13 @@
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    width: "100%",
+    backgroundColor: theme.palette.background.paper,
+    display: "flex",
+    flexDirection: "row",
+    alignItems: "flex-start",
+  },
+}));
+
+export default useStyles;

--- a/src/styles/SideNavStyles.js
+++ b/src/styles/SideNavStyles.js
@@ -2,8 +2,11 @@ import { makeStyles } from "@material-ui/core/styles";
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    backgroundColor: "#1D1566",
+    backgroundColor: "gray",
     alignItems: "center",
+    marginTop: 10,
+    marginRight: 20,
+    width: 300,
   },
   EventHeader: {
     textAlign: "center",

--- a/src/styles/SideNavStyles.js
+++ b/src/styles/SideNavStyles.js
@@ -1,0 +1,18 @@
+import { makeStyles } from "@material-ui/core/styles";
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    backgroundColor: "#1D1566",
+    alignItems: "center",
+  },
+  EventHeader: {
+    textAlign: "center",
+    color: "white",
+  },
+  ListItem: {
+    borderBottom: "solid white",
+    borderBottomWidth: "thin",
+  },
+}));
+
+export default useStyles;


### PR DESCRIPTION
- Added a separate sidebar component 

- Added a component for the sidebar/hotposts combo. The data populating both of these components will be determined by the same thing (the category we are in), I thought it made sense to have them contained in a parent component so that we can simply pass a prop to this parent which will allows us to manage the data being passed to the children.  I.e. if we use this sidebarhotpost component on the Home page, we pass a prop like category="Home", we can send the appropriate api request to just get base events in our HotPostSideNav container and pass that down to our side nav. The fact that we are in the "home" category also determined what will be loaded in our hotposts section, load that appropriate data and pass it down to the hotposts. If we click on an event like "Golf" in the sidebar, we will likely be rendering the category screen and reusing this SideBarHotPost container by passing a prop which will likely be the Golf Event Id etc 

- I tried the Smarkets API in the SideBarNavPost component but I was getting getting blocked due to cross origin request policies. From what I read we might have to make a proxy server or something to get around this. For now I just hardcoded some events, but I think we are good to just work on getting these api calls up and running now