### PR TITLE
Added queries to mongodb database for events/tournaments/markets

### DIFF
--- a/client/src/SideNav.jsx
+++ b/client/src/SideNav.jsx
@@ -29,7 +29,7 @@ export default function SideNav({ events }) {
               button
               onClick={() => goToEvent(event)}
             >
-              <EventLink eventtitle={event.EventName} />
+              <EventLink eventtitle={event.Name} />
             </ListItem>
           </>
         ))}

--- a/client/src/SideNavHotPost.jsx
+++ b/client/src/SideNavHotPost.jsx
@@ -18,8 +18,8 @@ export default function SideNavHotPost(props) {
     props.history.push(`/forum/${id}`);
   };
 
-  const fetchEvents = async (cat_id) => {
-    const events = await axios.get("/api/events".concat(cat_id));
+  const fetchEvents = async () => {
+    const events = await axios.get("/api/events");
     console.log(events.data);
     setChildEvents(events.data);
   };
@@ -32,7 +32,7 @@ export default function SideNavHotPost(props) {
       switch (props.categoryid) {
         case "Home":
           console.log("Grabbing baseline events for home page");
-          fetchEvents("");
+          fetchEvents();
           break;
 
         default:

--- a/server/db_queries.js
+++ b/server/db_queries.js
@@ -1,0 +1,62 @@
+const mongoose = require("mongoose");
+const express = require("express");
+const router = express.Router();
+const conn_string =
+  "mongodb+srv://admin:passwordpassword@cluster0.wapen.mongodb.net/plusev?retryWrites=true&w=majority";
+
+//connect to our database which currently has 3 tables:
+//events/tournaments/markets
+mongoose.connect(conn_string, {
+  useNewUrlParser: true,
+  useCreateIndex: true,
+  useUnifiedTopology: true,
+});
+
+mongoose.connection.on("connected", () => {
+  console.log("Successfully connected to the plusev database.");
+});
+
+mongoose.connection.on("error", (err) => {
+  console.error("Error connecting to mongodb", err);
+});
+
+//defining the schemas/models corresponding to the existing tables in the db
+
+const eventschema = new mongoose.Schema({});
+const tournamentschema = new mongoose.Schema({});
+const marketschema = new mongoose.Schema({});
+
+var events = mongoose.model("event", eventschema);
+var tournaments = mongoose.model("tournament", tournamentschema);
+var markets = mongoose.model("market", marketschema);
+
+router.get("/api/events", async (req, res, next) => {
+  try {
+    events_data = await events.find({});
+    res.send(events_data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get("/api/tournaments", async (req, res) => {
+  try {
+    let eventid = parseInt(req.query.eventid);
+    tournaments_data = await tournaments.find({ EventID: eventid });
+    res.send(tournaments_data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+router.get("/api/markets", async (req, res) => {
+  try {
+    let tournamentid = parseInt(req.query.tournamentid);
+    markets_data = await markets.find({ TournamentID: tournamentid });
+    res.send(markets_data);
+  } catch (err) {
+    next(err);
+  }
+});
+
+module.exports = router;

--- a/server/db_queries.js
+++ b/server/db_queries.js
@@ -1,8 +1,7 @@
 const mongoose = require("mongoose");
 const express = require("express");
 const router = express.Router();
-const conn_string =
-  "mongodb+srv://admin:passwordpassword@cluster0.wapen.mongodb.net/plusev?retryWrites=true&w=majority";
+const conn_string = require("./configs");
 
 //connect to our database which currently has 3 tables:
 //events/tournaments/markets
@@ -24,39 +23,54 @@ mongoose.connection.on("error", (err) => {
 
 const eventschema = new mongoose.Schema({});
 const tournamentschema = new mongoose.Schema({});
+const matchschema = new mongoose.Schema({});
 const marketschema = new mongoose.Schema({});
 
 var events = mongoose.model("event", eventschema);
 var tournaments = mongoose.model("tournament", tournamentschema);
+var matches = mongoose.model("matche", matchschema);
 var markets = mongoose.model("market", marketschema);
 
-router.get("/api/events", async (req, res, next) => {
-  try {
-    events_data = await events.find({});
-    res.send(events_data);
-  } catch (err) {
-    next(err);
-  }
-});
+class dbHandler {
+  constructor() {}
 
-router.get("/api/tournaments", async (req, res) => {
-  try {
-    let eventid = parseInt(req.query.eventid);
-    tournaments_data = await tournaments.find({ EventID: eventid });
-    res.send(tournaments_data);
-  } catch (err) {
-    next(err);
+  async getEvents() {
+    try {
+      const eventsdata = await events.find({});
+      return eventsdata;
+    } catch (err) {
+      console.log(err);
+      return {};
+    }
   }
-});
 
-router.get("/api/markets", async (req, res) => {
-  try {
-    let tournamentid = parseInt(req.query.tournamentid);
-    markets_data = await markets.find({ TournamentID: tournamentid });
-    res.send(markets_data);
-  } catch (err) {
-    next(err);
+  async getTournaments(eventtypeid) {
+    try {
+      console.log(eventtypeid);
+      const tournamentsdata = await tournaments.find({ EventID: eventtypeid });
+      return tournamentsdata;
+    } catch (err) {
+      return {};
+    }
   }
-});
 
-module.exports = router;
+  async getMatches(tournamentid) {
+    try {
+      const matches_data = await matches.find({ TournamentID: tournamentid });
+      return matches_data;
+    } catch (err) {
+      return {};
+    }
+  }
+
+  async getMarkets(matchid) {
+    try {
+      const market_data = await markets.find({ MatchID: matchid });
+      return market_data;
+    } catch (err) {
+      return err;
+    }
+  }
+}
+
+module.exports = dbHandler;

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4,6 +4,28 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/bson": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/bson/-/bson-4.0.3.tgz",
+      "integrity": "sha512-mVRvYnTOZJz3ccpxhr3wgxVmSeiYinW+zlzQz3SXWaJmD1DuL05Jeq7nKw3SnbKmbleW5qrLG5vdyWe/A9sXhw==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/mongodb": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@types/mongodb/-/mongodb-3.6.3.tgz",
+      "integrity": "sha512-6YNqGP1hk5bjUFaim+QoFFuI61WjHiHE1BNeB41TA00Xd2K7zG4lcWyLLq/XtIp36uMavvS5hoAUJ+1u/GcX2Q==",
+      "requires": {
+        "@types/bson": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "14.14.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
+      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw=="
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -17,6 +39,20 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
+    },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -34,6 +70,11 @@
         "raw-body": "2.4.0",
         "type-is": "~1.6.17"
       }
+    },
+    "bson": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
+      "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg=="
     },
     "bytes": {
       "version": "3.1.0",
@@ -63,6 +104,11 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -70,6 +116,11 @@
       "requires": {
         "ms": "2.0.0"
       }
+    },
+    "denque": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -211,10 +262,26 @@
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "kareem": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.2.tgz",
+      "integrity": "sha512-STHz9P7X2L4Kwn72fA4rGyqyXdmrMSdxqHx9IXon/FXluXieaFA6KJ2upcHAHxQPQ0LeM/OjLrhFxifHewOALQ=="
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+    },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -244,6 +311,82 @@
         "mime-db": "1.45.0"
       }
     },
+    "mongodb": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.3.tgz",
+      "integrity": "sha512-rOZuR0QkodZiM+UbQE5kDsJykBqWi0CL4Ec2i1nrGrUI3KO11r6Fbxskqmq3JK2NH7aW4dcccBuUujAP0ERl5w==",
+      "requires": {
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "require_optional": "^1.0.1",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
+      }
+    },
+    "mongoose": {
+      "version": "5.11.13",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-5.11.13.tgz",
+      "integrity": "sha512-rXbaxSJfLnKKO2RTm8MKt65glrtfKDc4ATEb6vEbbzsVGCiLut753K5axdpyvE7KeTH7GOh4LzmuQLOvaaWOmA==",
+      "requires": {
+        "@types/mongodb": "^3.5.27",
+        "bson": "^1.1.4",
+        "kareem": "2.3.2",
+        "mongodb": "3.6.3",
+        "mongoose-legacy-pluralize": "1.0.2",
+        "mpath": "0.8.3",
+        "mquery": "3.2.3",
+        "ms": "2.1.2",
+        "regexp-clone": "1.0.0",
+        "safe-buffer": "5.2.1",
+        "sift": "7.0.1",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
+    "mongoose-legacy-pluralize": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
+      "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ=="
+    },
+    "mpath": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.3.tgz",
+      "integrity": "sha512-eb9rRvhDltXVNL6Fxd2zM9D4vKBxjVVQNLNijlj7uoXUy19zNDsIif5zR+pWmPCWNKwAtqyo4JveQm4nfD5+eA=="
+    },
+    "mquery": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-3.2.3.tgz",
+      "integrity": "sha512-cIfbP4TyMYX+SkaQ2MntD+F2XbqaBHUYWk3j+kqdDztPWok3tgyssOZxMHMtzbV1w9DaSlvEea0Iocuro41A4g==",
+      "requires": {
+        "bluebird": "3.5.1",
+        "debug": "3.1.0",
+        "regexp-clone": "^1.0.0",
+        "safe-buffer": "5.1.2",
+        "sliced": "1.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -271,6 +414,11 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "proxy-addr": {
       "version": "2.0.6",
@@ -302,6 +450,39 @@
         "unpipe": "1.0.0"
       }
     },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "regexp-clone": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-1.0.0.tgz",
+      "integrity": "sha512-TuAasHQNamyyJ2hb97IuBEif4qBHGjPHBS64sZwytpLEqtBQ1gPJTnOaQ6qmpET16cK14kkjbazl6+p0RRv0yw=="
+    },
+    "require_optional": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
+    },
+    "resolve-from": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -311,6 +492,20 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "send": {
       "version": "0.17.1",
@@ -355,10 +550,37 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
       "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
     },
+    "sift": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-7.0.1.tgz",
+      "integrity": "sha512-oqD7PMJ+uO6jV9EQCl0LrRw1OwsiPsiFQR5AR30heR+4Dl7jBBbDLnNvWiak20tzZlSE1H7RB30SX/1j/YYT7g=="
+    },
+    "sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "toidentifier": {
       "version": "1.0.0",
@@ -378,6 +600,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "body-parser": "^1.19.0",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "mongoose": "^5.11.13"
   },
   "devDependencies": {
     "concurrently": "^4.0.1"

--- a/server/server.js
+++ b/server/server.js
@@ -1,34 +1,12 @@
 const express = require("express");
 const bodyParser = require("body-parser");
+const route_handler = require("./db_queries");
 
 const app = express();
 const port = process.env.PORT || 5000;
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
-
-app.get("/api/events", (req, res) => {
-  res.send([
-    {
-      EventName: "Golf",
-      EventId: 1,
-    },
-    { EventName: "Rugby", EventId: 2 },
-    { EventName: "Tennis", EventId: 3 },
-    { EventName: "Hurling", EventId: 4 },
-    { EventName: "Baseball", EventId: 5 },
-    { EventName: "Basketball", EventId: 6 },
-    { EventName: "Cricket", EventId: 7 },
-    { EventName: "Politics", EventId: 7 },
-  ]);
-});
-
-///stuff about a post request from an example just left it in here
-app.post("/api/world", (req, res) => {
-  console.log(req.body);
-  res.send(
-    `I received your POST request. This is what you sent me: ${req.body.post}`
-  );
-});
+app.use(route_handler);
 
 app.listen(port, () => console.log(`Listening on port ${port}`));

--- a/server/server.js
+++ b/server/server.js
@@ -1,12 +1,40 @@
 const express = require("express");
 const bodyParser = require("body-parser");
-const route_handler = require("./db_queries");
+const router = express.Router();
+const dbHandler = require("./db_queries");
+
+const db_handler = new dbHandler();
+
+console.log(db_handler);
+
+router.get("/api/events", async (req, res, next) => {
+  data = await db_handler.getEvents();
+  res.send(data);
+});
+
+router.get("/api/tournaments", async (req, res, next) => {
+  let eventid = parseInt(req.query.eventid);
+  data = await db_handler.getTournaments(eventid);
+  res.send(data);
+});
+
+router.get("/api/matches", async (req, res, next) => {
+  let tournamentid = parseInt(req.query.tournamentid);
+  data = await db_handler.getMatches(tournamentid);
+  res.send(data);
+});
+
+router.get("/api/markets", async (req, res, next) => {
+  let matchid = parseInt(req.query.matchid);
+  data = await db_handler.getMarkets(matchid);
+  res.send(data);
+});
 
 const app = express();
 const port = process.env.PORT || 5000;
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true }));
-app.use(route_handler);
+app.use(router);
 
 app.listen(port, () => console.log(`Listening on port ${port}`));


### PR DESCRIPTION
I set up a database with the following collections: 

Collectionname           fields
events                         Name | EventID
tournaments               Name | TournamentID | EventID
markets                       Name | MarketId | TournamentID 

Added a file called db_queries.js which makes the connection to the cluster and sets up a router to handle incoming get requests for events/markets/tournaments. I made a slight change in the front end to just populate the home page side bar with the base events to test that it was working. 

We should be able to start adding some functionality for clicking on events -> populating tournaments -> clicking on tournaments -> populating markets now I think. 